### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Demo site:  <http://coeverydemo.novasoftware.cn/> (Recommended)
 User Name: admin  
 Password: 123456789 
 
-##How to install it
+## How to install it
 
 If you'd like to deploy Coevery on your computer, please follow the instructions [Installing with Microsoft Web Platform Installer](https://github.com/Coevery/Coevery/wiki/Installing-with-Microsoft-Web-Platform-Installer)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
